### PR TITLE
- updated country detail label text alignment based on RTL

### DIFF
--- a/NMLocalizedPhoneCountryView/NMLocalizedPhoneCountryView.swift
+++ b/NMLocalizedPhoneCountryView/NMLocalizedPhoneCountryView.swift
@@ -231,6 +231,7 @@ public class NMLocalizedPhoneCountryView: NMNibView {
         flagImageView.image = selectedCountry.flag
         countryDetailsLabel.font = self.getFontForSymbolicTrait(trait: selectedCountryFontTrait)
         countryDetailsLabel.textColor = textColor
+        countryDetailsLabel.textAlignment = localeSetup.isOtherLocale() ? .right : .left
         if showPhoneCodeInView && showCountryCodeInView {
             countryDetailsLabel.text = "(\(selectedCountry.code)) \(selectedCountry.phoneCode)"
 


### PR DESCRIPTION
Updated `countryDetailsLabel` text alignment based on `currentLocale`

**Left Aligned for LTR text**

<img width="559" alt="Screen Shot 2019-06-25 at 3 29 43 PM" src="https://user-images.githubusercontent.com/24762663/60094864-401eef80-975e-11e9-90a5-084207932891.png">

**Right Aligned for RTL text**

<img width="559" alt="Screen Shot 2019-06-25 at 3 29 47 PM" src="https://user-images.githubusercontent.com/24762663/60094866-401eef80-975e-11e9-94b3-660a8954bd6c.png">
