### PR TITLE
Bump version 1.0.7 - Updated presentation of internal view controller

### DIFF
--- a/NMLocalizedPhoneCountryView.podspec
+++ b/NMLocalizedPhoneCountryView.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "NMLocalizedPhoneCountryView"
-  spec.version      = "1.0.6"
+  spec.version      = "1.0.7"
   spec.summary      = "iOS library to add support for selecting a country and its international phone code in your app"
   spec.description      = <<-DESC
   iOS library to add support for selecting a country and its international phone code in your app with localized country names. It can also exclude countries based on countryCodes. Inspiration from https://github.com/kizitonwose/CountryPickerView pod.

--- a/NMLocalizedPhoneCountryView/NMLocalizedPhoneCountryView.swift
+++ b/NMLocalizedPhoneCountryView/NMLocalizedPhoneCountryView.swift
@@ -150,6 +150,7 @@ public class NMLocalizedPhoneCountryView: NMNibView {
     @IBOutlet weak var spacingConstraint: NSLayoutConstraint!
     @IBOutlet public weak var flagImageView: UIImageView!
     @IBOutlet fileprivate weak var countryDetailsLabel: UILabel!
+    internal var isViewControllerPushed: Bool = false
     public var jsonCountries: Array<Any>? = nil
     public var localeSetup : NMLocaleSetup = NMLocaleSetup() {
         didSet { setup() }
@@ -263,12 +264,14 @@ public class NMLocalizedPhoneCountryView: NMNibView {
         if let viewController = viewController as? UINavigationController {
             delegate?.localizedPhoneCountryView(self, willShow: countryVc)
             viewController.pushViewController(countryVc, animated: true) {
+                self.isViewControllerPushed = true
                 self.delegate?.localizedPhoneCountryView(self, didShow: countryVc)
             }
         } else {
             let navigationVC = UINavigationController(rootViewController: countryVc)
             delegate?.localizedPhoneCountryView(self, willShow: countryVc)
             viewController.present(navigationVC, animated: true) {
+                self.isViewControllerPushed = false
                 self.delegate?.localizedPhoneCountryView(self, didShow: countryVc)
             }
         }

--- a/NMLocalizedPhoneCountryView/NMLocalizedPhoneCountryViewController.swift
+++ b/NMLocalizedPhoneCountryView/NMLocalizedPhoneCountryViewController.swift
@@ -149,8 +149,11 @@ extension NMLocalizedPhoneCountryViewController {
     }
     
     @objc private func close() {
-        self.navigationController?.popViewController(animated: true)
-        self.navigationController?.dismiss(animated: true, completion: nil)
+        if localizedPhoneCountryView.isViewControllerPushed {
+            self.navigationController?.popViewController(animated: true)
+        } else {
+            self.navigationController?.dismiss(animated: true, completion: nil)
+        }
     }
 }
 

--- a/NMLocalizedPhoneCountryViewDemo/Pods/Target Support Files/NMLocalizedPhoneCountryView/Info.plist
+++ b/NMLocalizedPhoneCountryViewDemo/Pods/Target Support Files/NMLocalizedPhoneCountryView/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.6</string>
+	<string>1.0.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/NMLocalizedPhoneCountryViewDemo/Pods/Target Support Files/NMLocalizedPhoneCountryView/ResourceBundle-NMLocalizedPhoneCountryView-Info.plist
+++ b/NMLocalizedPhoneCountryViewDemo/Pods/Target Support Files/NMLocalizedPhoneCountryView/ResourceBundle-NMLocalizedPhoneCountryView-Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.6</string>
+	<string>1.0.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
- added a `Bool` that determines whether the internal view controller is pushed or presented
- the view controller will `pop` or `dismiss` on close accordingly